### PR TITLE
Commit the diffuse-tint shader variant.

### DIFF
--- a/Assets/Examples/Assets/Shaders/KT_Mobile-Diffuse-tint.shader
+++ b/Assets/Examples/Assets/Shaders/KT_Mobile-Diffuse-tint.shader
@@ -1,0 +1,35 @@
+// Simplified Diffuse shader. Differences from regular Diffuse one:
+// - no Main Color
+
+Shader "KT/Mobile/DiffuseTint" {
+Properties {
+	_MainTex ("Base (RGB)", 2D) = "white" {}
+	_Color ("Tint", Color) = (1,1,1,1)
+}
+SubShader {
+	Tags { "RenderType"="Opaque" }
+	LOD 150
+
+CGPROGRAM
+// Mobile improvement: noforwardadd
+// http://answers.unity3d.com/questions/1200437/how-to-make-a-conditional-pragma-surface-noforward.html
+// http://gamedev.stackexchange.com/questions/123669/unity-surface-shader-conditinally-noforwardadd
+#pragma surface surf Lambert
+
+sampler2D _MainTex;
+fixed4 _Color;
+
+struct Input {
+	float2 uv_MainTex;
+};
+
+void surf (Input IN, inout SurfaceOutput o) {
+	fixed4 c = tex2D(_MainTex, IN.uv_MainTex) * _Color;
+	o.Albedo = c.rgb;
+	o.Alpha = c.a;
+}
+ENDCG
+}
+
+Fallback "Mobile/VertexLit"
+}

--- a/Assets/Examples/Assets/Shaders/KT_Mobile-Diffuse-tint.shader.meta
+++ b/Assets/Examples/Assets/Shaders/KT_Mobile-Diffuse-tint.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 3f0d4a2e325f9c24f8251b7b8534a096
+timeCreated: 1473365071
+licenseType: Free
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a mobile diffuse w/tint shader to the shader assets. Derived directly from the KT_Module-Diffuse.shader, with a color multiply of the diffuse texture sampler.
