### PR TITLE
Support Mac UnityEngine location

### DIFF
--- a/Assets/Editor/Scripts/AssetBundler.cs
+++ b/Assets/Editor/Scripts/AssetBundler.cs
@@ -235,7 +235,18 @@ public class AssetBundler
             .Select(path => "Assets/Plugins/Managed/" + Path.GetFileNameWithoutExtension(path))
             .ToList();
 
-        string unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.exe", "Data/Managed/");
+        string unityAssembliesLocation;
+        switch (System.Environment.OSVersion.Platform)
+        {
+            case PlatformID.MacOSX:
+            case PlatformID.Unix:
+                unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.app", "Unity.app/Contents/Frameworks/Managed/");
+                break;
+            case PlatformID.Win32NT:
+            default:
+                unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.exe", "Data/Managed/");
+                break;
+        }
 
         managedReferences.Add(unityAssembliesLocation + "UnityEngine");
 


### PR DESCRIPTION
Reopening, confirmed working. With this small fix, the example mod builds and loads fine on Mac.
