### PR TITLE
Use https for Google Fonts reference

### DIFF
--- a/Manual/ExampleManualPage.html
+++ b/Manual/ExampleManualPage.html
@@ -4,10 +4,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Keep Talking and Nobody Explodes Example Manual Page</title>
     <meta name="viewport" content="initial-scale=1"> 
-	<link href='http://fonts.googleapis.com/css?family=Special+Elite' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Special+Elite' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="css/normalize.css">
     <link rel="stylesheet" type="text/css" href="css/main.css">
-    <link href="css" rel="stylesheet" type="text/css">
 </head>
 <body>
 <div class="section">


### PR DESCRIPTION
This is required (at least in Chrome) for the common case of hosting a web manual via GitHub Pages, e.g. https://mtolly.github.io/ktane-resistors/Manual/ResistorsManual.html

Some examples of the font not being loaded:
https://cdn.rawgit.com/timtmok/ktanemod-combination_lock/master/Manual/CombinationLock.html
https://bfdev.github.io/Switches/Manual/

Also removed a broken css reference.
