### PR TITLE
fixed inability to build Assetbundle on macOS

### DIFF
--- a/Assets/Editor/Scripts/AssetBundler.cs
+++ b/Assets/Editor/Scripts/AssetBundler.cs
@@ -243,7 +243,7 @@ public class AssetBundler
         {
             case PlatformID.MacOSX:
             case PlatformID.Unix:
-                unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.app", "Unity.app/Contents/Frameworks/Managed/");
+                unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.app", "Unity.app/Contents/Managed/");
                 break;
             case PlatformID.Win32NT:
             default:


### PR DESCRIPTION
- I’ve changed a file directory since in Unity 5.4.2p4 on macOS, the
meta file to build bundle is located in Unity.app/Contents/Managed/;