### PR TITLE
Additions and fixes to AssetBundler and TestHarness

### DIFF
--- a/Assets/Editor/Scripts/AssetBundler.cs
+++ b/Assets/Editor/Scripts/AssetBundler.cs
@@ -1,10 +1,10 @@
-﻿using UnityEngine;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using UnityEditor;
 using System.Linq;
-using System;
 using System.Reflection;
+using UnityEditor;
+using UnityEngine;
 
 /// <summary>
 /// 
@@ -633,6 +633,17 @@ public class AssetBundler
                     materialInfo.ShaderNames = new List<string>();
                     foreach(Material material in renderer.sharedMaterials)
                     {
+                        if (material == null)
+                        {
+                            var obj = renderer.transform;
+                            var str = new List<string>();
+                            while (obj != null)
+                            {
+                                str.Add(obj.gameObject.name);
+                                obj = obj.parent;
+                            }
+                            Debug.LogErrorFormat("There is an unassigned material on the following object: {0}", string.Join(" > ", str.ToArray()));
+                        }
                         materialInfo.ShaderNames.Add(material.shader.name);
 
                         if(material.shader.name == "Standard")

--- a/Assets/TestHarness/TestHarness.cs
+++ b/Assets/TestHarness/TestHarness.cs
@@ -434,10 +434,9 @@ public class TestHarness : MonoBehaviour
             {
                 if (f.FieldType.Equals(typeof(KMBombInfo)))
                 {
-                    KMBombInfo component = (KMBombInfo)f.GetValue(s);
-                    if (component.OnBombExploded != null) fakeInfo.Detonate += new FakeBombInfo.OnDetonate(component.OnBombExploded);
-                    if (component.OnBombSolved != null) fakeInfo.HandleSolved += new FakeBombInfo.OnSolved(component.OnBombSolved);
-                    continue;
+                    KMBombInfo component = (KMBombInfo) f.GetValue(s);
+                    fakeInfo.Detonate += delegate { if (component.OnBombExploded != null) component.OnBombExploded(); };
+                    fakeInfo.HandleSolved += delegate { if (component.OnBombSolved != null) component.OnBombSolved(); };
                 }
             }
         }

--- a/Assets/TestHarness/TestHarness.cs
+++ b/Assets/TestHarness/TestHarness.cs
@@ -184,8 +184,6 @@ public class FakeBombInfo : MonoBehaviour
     public delegate void LightsOn();
     public LightsOn ActivateLights;
 
-    private Widget widgetHandler;
-
     void FixedUpdate()
     {
         if (solved) return;
@@ -820,7 +818,7 @@ public class TestHarness : MonoBehaviour
 
         GameObject o = new GameObject("Light");
         o.transform.localPosition = new Vector3(0, 3, 0);
-        o.transform.localRotation = Quaternion.Euler(new Vector3(50, -30, 0));
+        o.transform.localRotation = Quaternion.Euler(new Vector3(130, -30, 0));
         testLight = o.AddComponent<Light>();
         testLight.type = LightType.Directional;
     }

--- a/Assets/TestHarness/TestHarness.cs
+++ b/Assets/TestHarness/TestHarness.cs
@@ -797,10 +797,7 @@ public class TestHarness : MonoBehaviour
                     MethodInfo method = type.GetMethod("ProcessTwitchCommand", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
                     if (method != null)
-                    {
-                        Debug.LogFormat("<> method: {0}", method);
                         StartCoroutine(SimulateModule(component, module.transform, method, command));
-                    }
                 }
             }
             command = "";


### PR DESCRIPTION
* AssetBundler throws a NullReferenceException when a material is unassigned. This change adds a log message that helps find the offending object in the prefab tree.
* TestHarness now includes the textbox and functionality for testing Twitch Plays integration.