### PR TITLE
Fixed bug which causes the custom mission editor pane to not render if a ModConfig is not yet made

### DIFF
--- a/Assets/Editor/Scripts/ModConfig.cs
+++ b/Assets/Editor/Scripts/ModConfig.cs
@@ -67,6 +67,10 @@ public sealed class ModConfig : ScriptableObject
             if (instance == null)
             {
                 instance = Resources.Load<ModConfig>("ModConfig");
+                if (instance == null)
+                {
+                    ModKitSettingsEditor.CreateModConfig(out instance);
+                }
             }
             return instance;
         }

--- a/Assets/Editor/Scripts/ModKitSettingsEditor.cs
+++ b/Assets/Editor/Scripts/ModKitSettingsEditor.cs
@@ -15,21 +15,26 @@ public class ModKitSettingsEditor : Editor
         var modConfig = ModConfig.Instance;
         if (modConfig == null)
         {
-            modConfig = ScriptableObject.CreateInstance<ModConfig>();
-            string properPath = Path.Combine(Path.Combine(Application.dataPath, "Editor"), "Resources");
-            if (!Directory.Exists(properPath))
-            {
-                AssetDatabase.CreateFolder("Assets/Editor", "Resources");
-            }
-
-            string fullPath = Path.Combine(
-                Path.Combine("Assets", "Editor"),
-                Path.Combine("Resources", "ModConfig.asset")
-            );
-            AssetDatabase.CreateAsset(modConfig, fullPath);
-            ModConfig.Instance = modConfig;
+            CreateModConfig(out modConfig);
         }
         UnityEditor.Selection.activeObject = modConfig;
+    }
+
+    public static void CreateModConfig(out ModConfig modConfig)
+    {
+        modConfig = ScriptableObject.CreateInstance<ModConfig>();
+        string properPath = Path.Combine(Path.Combine(Application.dataPath, "Editor"), "Resources");
+        if (!Directory.Exists(properPath))
+        {
+            AssetDatabase.CreateFolder("Assets/Editor", "Resources");
+        }
+
+        string fullPath = Path.Combine(
+            Path.Combine("Assets", "Editor"),
+            Path.Combine("Resources", "ModConfig.asset")
+        );
+        AssetDatabase.CreateAsset(modConfig, fullPath);
+        ModConfig.Instance = modConfig;
     }
 
     public override void OnInspectorGUI()

--- a/Assets/TestHarness/EdgeworkConfigurations/Default.asset
+++ b/Assets/TestHarness/EdgeworkConfigurations/Default.asset
@@ -9,7 +9,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 34a4fefeeafb9a5439cfbd83306ba467, type: 3}
-  m_Name: config
+  m_Name: Default
   m_EditorClassIdentifier: 
   SerialNumberType: 0
   CustomSerialNumber: 


### PR DESCRIPTION
There is currently a small bug where the custom mission editor tries to get the mod id from ModConfig but no ModConfig exists yet. This build should fix this.