### PR TITLE
Mac/Linux building fix

### DIFF
--- a/Assets/Editor/Scripts/AssetBundler.cs
+++ b/Assets/Editor/Scripts/AssetBundler.cs
@@ -62,6 +62,11 @@ public class AssetBundler
     /// List of MonoScripts modified during the bundling process that need to be restored after.
     /// </summary>
     private List<string> scriptPathsToRestore = new List<string>();
+    
+    /// <summary>
+    /// A variable for holding the current BuildTarget, for Mac compatibility.
+    /// </summary>
+    BuildTarget target = BuildTarget.StandaloneWindows;
     #endregion
 
     [MenuItem("Keep Talking ModKit/Build AssetBundle _F6", priority = 10)]
@@ -92,6 +97,7 @@ public class AssetBundler
 
         bundler.assemblyName = ModConfig.ID;
         bundler.outputFolder = ModConfig.OutputFolder + "/" + bundler.assemblyName;
+        if (System.Environment.OSVersion.Platform == PlatformID.MacOSX) bundler.target = BuildTarget.StandaloneOSXUniversal;
 
         bool success = false;
 
@@ -242,12 +248,12 @@ public class AssetBundler
         switch (System.Environment.OSVersion.Platform)
         {
             case PlatformID.MacOSX:
-            case PlatformID.Unix:
-                unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.app", "Unity.app/Contents/Managed/");
+                unityAssembliesLocation = EditorApplication.applicationPath + "/Contents/Managed/";
                 break;
             case PlatformID.Win32NT:
+            case PlatformID.Unix:
             default:
-                unityAssembliesLocation = EditorApplication.applicationPath.Replace("Unity.exe", "Data/Managed/");
+                unityAssembliesLocation = Path.Combine(Path.GetDirectoryName(EditorApplication.applicationPath), @"Data/Managed/");
                 break;
         }
 
@@ -265,7 +271,7 @@ public class AssetBundler
         int apiCompatibilityLevel = 1; //NET_2_0 compatibility level is enum value 1
         Assembly assembly = Assembly.GetAssembly(typeof(MonoScript));
         var monoIslandType = assembly.GetType("UnityEditor.Scripting.MonoIsland");
-        object monoIsland = Activator.CreateInstance(monoIslandType, BuildTarget.StandaloneWindows, apiCompatibilityLevel, scriptArray, referenceArray, defineArray, outputFilename);
+        object monoIsland = Activator.CreateInstance(monoIslandType, target, apiCompatibilityLevel, scriptArray, referenceArray, defineArray, outputFilename);
 
         //MonoCompiler itself
         var monoCompilerType = assembly.GetType("UnityEditor.Scripting.Compilers.MonoCSharpCompiler");
@@ -423,7 +429,7 @@ public class AssetBundler
         BuildPipeline.BuildAssetBundles(
             TEMP_BUILD_FOLDER, 
             BuildAssetBundleOptions.DeterministicAssetBundle | BuildAssetBundleOptions.CollectDependencies, 
-            BuildTarget.StandaloneWindows);
+            target);
 #pragma warning restore 618
 
         //We are only interested in the BUNDLE_FILENAME bundle (and not the extra AssetBundle or the manifest files


### PR DESCRIPTION
- UnityEngine.dll on Linux is located at Unity/Editor/Data/Managed, which can't use the current Replace method due to the fact that Linux's executable for Unity has no file extension. There's also no need to replace the Mac location when you can just add to it. [Note that I'm basing this off of the original version, I don't know if that's how Mac's filesystem works or not.]

- Incorporate Royal_Flu$h and AshTheBash's fix for Mac building. This requires changing each BuildTarget from StandaloneWindows to StandaloneOSX. I simply added a variable that will set the build target based on what the OS is. Linux is not affected by this bug.