### PR TITLE
Actually fix Mac building

### DIFF
--- a/Assets/Editor/Scripts/AssetBundler.cs
+++ b/Assets/Editor/Scripts/AssetBundler.cs
@@ -97,7 +97,7 @@ public class AssetBundler
 
         bundler.assemblyName = ModConfig.ID;
         bundler.outputFolder = ModConfig.OutputFolder + "/" + bundler.assemblyName;
-        if (System.Environment.OSVersion.Platform == PlatformID.MacOSX) bundler.target = BuildTarget.StandaloneOSXUniversal;
+        if (Application.platform == RuntimePlatform.OSXEditor) bundler.target = BuildTarget.StandaloneOSXUniversal;
 
         bool success = false;
 
@@ -245,13 +245,13 @@ public class AssetBundler
             .ToList();
 
         string unityAssembliesLocation;
-        switch (System.Environment.OSVersion.Platform)
+        switch (Application.platform)
         {
-            case PlatformID.MacOSX:
+            case RuntimePlatform.OSXEditor:
                 unityAssembliesLocation = EditorApplication.applicationPath + "/Contents/Managed/";
                 break;
-            case PlatformID.Win32NT:
-            case PlatformID.Unix:
+            case RuntimePlatform.LinuxEditor:
+            case RuntimePlatform.WindowsEditor:
             default:
                 unityAssembliesLocation = Path.Combine(Path.GetDirectoryName(EditorApplication.applicationPath), @"Data/Managed/");
                 break;


### PR DESCRIPTION
Swapped OSVersion.Platform / PlatformID with Application.Platform / RuntimeVersion.
Mac should properly return MacOSX rather than Unix.