### PR TITLE
Change extension methods on modded battery querying

### DIFF
--- a/Assets/Scripts/KMBombInfoExtensions.cs
+++ b/Assets/Scripts/KMBombInfoExtensions.cs
@@ -7,12 +7,8 @@ namespace KModkit
 {
     public enum Battery
     {
-        Unknown = 0,
-        Empty = 0,
-        D = 1,
-        AA = 2,
-        AAx3 = 3,
-        AAx4 = 4
+        AA,
+        D
     }
 
     public enum Port
@@ -277,13 +273,12 @@ namespace KModkit
 
         public static int GetBatteryCount(this KMBombInfo bombInfo, Battery batteryType)
         {
-            return GetBatteryCount(bombInfo, (int) batteryType);
-        }
-
-        public static int GetBatteryCount(this KMBombInfo bombInfo, int batteryType)
-        {
-            return GetBatteryEntries(bombInfo).Where((x) => x.numbatteries == batteryType)
-                .Sum((x) => x.numbatteries);
+            int[][] Holders =
+            {
+                new int[] { 2, 3, 4 },
+                new int[] { 1 }
+            };
+            return GetBatteryEntries(bombInfo).Where((x) => Holders[(int)batteryType].Contains(x.numbatteries)).Sum((x) => x.numbatteries);
         }
 
         public static int GetBatteryHolderCount(this KMBombInfo bombInfo)
@@ -291,14 +286,9 @@ namespace KModkit
             return GetBatteryEntries(bombInfo).Count();
         }
 
-        public static int GetBatteryHolderCount(this KMBombInfo bombInfo, Battery batteryType)
+        public static int GetBatteryHolderCount(this KMBombInfo bombInfo, int batteryCount)
         {
-            return GetBatteryHolderCount(bombInfo, (int) batteryType);
-        }
-
-        public static int GetBatteryHolderCount(this KMBombInfo bombInfo, int batteryType)
-        {
-            return GetBatteryEntries(bombInfo).Count(x => x.numbatteries == batteryType);
+            return GetBatteryEntries(bombInfo).Count((x) => x.numbatteries == batteryCount);
         }
 
         public static int GetPortCount(this KMBombInfo bombInfo)


### PR DESCRIPTION
- `GetBatteryCount(Battery.AA)` covers now-obsolete `AAx3` and `AAx4` entries to reduce tediousness and ambiguity of modded battery support
- Drop some methods and enum entries hardly used by modders as they could cause misunderstandings after applying the changes above