### PR TITLE
Save the assets when a mod is published so the workshop ID gets saved

### DIFF
--- a/Assets/Editor/Scripts/Workshop/WorkshopEditorWindow.cs
+++ b/Assets/Editor/Scripts/Workshop/WorkshopEditorWindow.cs
@@ -326,6 +326,8 @@ public class WorkshopEditorWindow : EditorWindow
         if (result.m_eResult == EResult.k_EResultOK)
         {
             currentWorkshopItem.WorkshopPublishedFileID = result.m_nPublishedFileId.m_PublishedFileId;
+            AssetDatabase.SaveAssets();
+
             PublishWorkshopChanges();
         }
     }


### PR DESCRIPTION
After publishing a new mod, if you were to close Unity before saving the workshop ID would be lost and you would have to grab it from the workshop again. This fixes that issue.