### PR TITLE
Needy module extension to set delay time

### DIFF
--- a/Assets/Scripts/KMNeedyModuleExtensions.cs
+++ b/Assets/Scripts/KMNeedyModuleExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Reflection;
+
+namespace KModkit
+{
+	public static class KMNeedyModuleExtensions
+	{
+		public static void SetResetDelayTime(this KMNeedyModule module, float min, float max)
+		{
+			if (module.gameObject.GetComponent("NeedyComponent") == null)
+				return; // Running in the Test Harness?
+			Type targetType = module.gameObject.GetComponent("NeedyComponent").GetType();
+			FieldInfo resetMin = targetType.GetField("ResetDelayMin", BindingFlags.Public | BindingFlags.Instance);
+			FieldInfo resetMax = targetType.GetField("ResetDelayMax", BindingFlags.Public | BindingFlags.Instance);
+			resetMin.SetValue(module.gameObject.GetComponent("NeedyComponent"), min);
+			resetMax.SetValue(module.gameObject.GetComponent("NeedyComponent"), max);
+		}
+	}
+}

--- a/Assets/Scripts/KMNeedyModuleExtensions.cs.meta
+++ b/Assets/Scripts/KMNeedyModuleExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f039622a83f1a47b5a075bd233709fdd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I'll be honest, I feel this is a pretty unorthodox thing to do, to be adding an extension class that modifies the game's NeedyComponents via Reflection; but I feel that the functionality added is sorely needed by modders. With this function, those making needy modules have control over how long the game will wait before reactivating their needies after they've been solved and temporarily disarmed.