### PR TITLE
Find UnityEngine.dll in a more cross-platform way

### DIFF
--- a/Assets/Editor/Scripts/AssetBundler.cs
+++ b/Assets/Editor/Scripts/AssetBundler.cs
@@ -244,20 +244,7 @@ public class AssetBundler
             .Select(path => "Assets/Plugins/Managed/" + Path.GetFileNameWithoutExtension(path))
             .ToList();
 
-        string unityAssembliesLocation;
-        switch (Application.platform)
-        {
-            case RuntimePlatform.OSXEditor:
-                unityAssembliesLocation = EditorApplication.applicationPath + "/Contents/Managed/";
-                break;
-            case RuntimePlatform.LinuxEditor:
-            case RuntimePlatform.WindowsEditor:
-            default:
-                unityAssembliesLocation = Path.Combine(Path.GetDirectoryName(EditorApplication.applicationPath), @"Data/Managed/");
-                break;
-        }
-
-        managedReferences.Add(unityAssembliesLocation + "UnityEngine");
+        managedReferences.Add(Path.Combine(EditorApplication.applicationContentsPath, "Managed/UnityEngine"));
 
         //Next we need to grab some type references and use reflection to build things the way Unity does.
         //Note that EditorUtility.CompileCSharp will do *almost* exactly the same thing, but it unfortunately


### PR DESCRIPTION
This seems to be a better way to find this file that doesn't depend on the Unity executable location at all. It turns out that Unity [has a variable](https://docs.unity3d.com/ScriptReference/EditorApplication-applicationContentsPath.html) for the Contents/Data directory path since at least Unity 4.x. I found it while trying to compile some really old mod that didn't have the current cross-plaform patch (822db0d4995d87e3873f967fd40013b5ec14598a) applied.